### PR TITLE
Clean up internal configuration and defaults

### DIFF
--- a/dogecoin/configuration.go
+++ b/dogecoin/configuration.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/rosetta-dogecoin/rosetta-dogecoin/configuration"
@@ -54,37 +53,28 @@ const (
 	// allFilePermissions specifies anyone can do anything
 	// to the file.
 	allFilePermissions = 0777
+
+	// defaults
+	defaultConfigurationDirectory = "/app"
+
+	mainnetConfigFile = "bitcoin-mainnet.conf"
+	testnetConfigFile = "bitcoin-testnet.conf"
+	mainnetTxDict = "mainnet-transaction.zstd"
+	testnetTxDict = "testnet-transaction.zstd"
 )
 
 var (
 	// configurationDirectory is the configuration path prefix
-	configurationDirectory string = os.Getenv("CONFIG_DIR")
-
-	// mainnetConfigPath is the path of the Bitcoin
-	// configuration file for mainnet.
-	mainnetConfigPath string
-
-	// testnetConfigPath is the path of the Bitcoin
-	// configuration file for testnet.
-	testnetConfigPath string
-
-	testnetTransactionDictionary string
-	mainnetTransactionDictionary string
-
-	// DataDirectory is the default location for all
-	// persistent data.
-	DataDirectory string = os.Getenv("DATA_DIR")
+	configurationDirectory string
 )
 
 // LoadConfiguration attempts to create a new Configuration
 // using the ENVs in the environment.
 func LoadConfiguration(baseDirectory string) (*configuration.Configuration, error) {
-	if len(configurationDirectory) == 0 && !strings.HasSuffix(os.Args[0], ".test") {
-		configurationDirectory = "/app"
-		mainnetConfigPath = configurationDirectory + "/bitcoin-mainnet.conf"
-		testnetConfigPath = configurationDirectory + "/bitcoin-testnet.conf"
-		testnetTransactionDictionary = configurationDirectory + "/testnet-transaction.zstd"
-		mainnetTransactionDictionary = configurationDirectory + "/mainnet-transaction.zstd"
+	configurationDirectory = os.Getenv("CONFIG_DIR")
+
+	if len(configurationDirectory) == 0 {
+		configurationDirectory = defaultConfigurationDirectory
 	}
 
 	config := &configuration.Configuration{}
@@ -125,12 +115,12 @@ func LoadConfiguration(baseDirectory string) (*configuration.Configuration, erro
 		config.GenesisBlockIdentifier = MainnetGenesisBlockIdentifier
 		config.Params = MainnetParams
 		config.Currency = MainnetCurrency
-		config.ConfigPath = mainnetConfigPath
+		config.ConfigPath = configurationDirectory + "/" + mainnetConfigFile
 		config.RPCPort = mainnetRPCPort
 		config.Compressors = []*encoder.CompressorEntry{
 			{
 				Namespace:      transactionNamespace,
-				DictionaryPath: mainnetTransactionDictionary,
+				DictionaryPath: configurationDirectory + "/" + mainnetTxDict,
 			},
 		}
 	case configuration.Testnet:
@@ -141,12 +131,12 @@ func LoadConfiguration(baseDirectory string) (*configuration.Configuration, erro
 		config.GenesisBlockIdentifier = TestnetGenesisBlockIdentifier
 		config.Params = TestnetParams
 		config.Currency = TestnetCurrency
-		config.ConfigPath = testnetConfigPath
+		config.ConfigPath = configurationDirectory + "/" + testnetConfigFile
 		config.RPCPort = testnetRPCPort
 		config.Compressors = []*encoder.CompressorEntry{
 			{
 				Namespace:      transactionNamespace,
-				DictionaryPath: testnetTransactionDictionary,
+				DictionaryPath: configurationDirectory + "/" + testnetTxDict,
 			},
 		}
 	case "":

--- a/dogecoin/configuration_test.go
+++ b/dogecoin/configuration_test.go
@@ -65,7 +65,7 @@ func TestLoadConfiguration(t *testing.T) {
 				GenesisBlockIdentifier: MainnetGenesisBlockIdentifier,
 				Port:                   1000,
 				RPCPort:                mainnetRPCPort,
-				ConfigPath:             mainnetConfigPath,
+				ConfigPath:             defaultConfigurationDirectory + "/" + mainnetConfigFile,
 				Pruning: &configuration.PruningConfiguration{
 					Frequency: pruneFrequency,
 					Depth:     pruneDepth,
@@ -74,7 +74,7 @@ func TestLoadConfiguration(t *testing.T) {
 				Compressors: []*encoder.CompressorEntry{
 					{
 						Namespace:      transactionNamespace,
-						DictionaryPath: mainnetTransactionDictionary,
+						DictionaryPath: defaultConfigurationDirectory + "/" + mainnetTxDict,
 					},
 				},
 			},
@@ -94,7 +94,7 @@ func TestLoadConfiguration(t *testing.T) {
 				GenesisBlockIdentifier: TestnetGenesisBlockIdentifier,
 				Port:                   1000,
 				RPCPort:                testnetRPCPort,
-				ConfigPath:             testnetConfigPath,
+				ConfigPath:             defaultConfigurationDirectory + "/" + testnetConfigFile,
 				Pruning: &configuration.PruningConfiguration{
 					Frequency: pruneFrequency,
 					Depth:     pruneDepth,
@@ -103,7 +103,7 @@ func TestLoadConfiguration(t *testing.T) {
 				Compressors: []*encoder.CompressorEntry{
 					{
 						Namespace:      transactionNamespace,
-						DictionaryPath: testnetTransactionDictionary,
+						DictionaryPath: defaultConfigurationDirectory + "/" + testnetTxDict,
 					},
 				},
 			},

--- a/main.go
+++ b/main.go
@@ -54,12 +54,15 @@ const (
 	// idleTimeout is the maximum amount of time to wait for the
 	// next request when keep-alives are enabled.
 	idleTimeout = 30 * time.Second
+
+	// default data directory
+	defaultDataDirectory = "/data"
 )
 
 var (
 	signalReceived = false
 
-	dataDirectory string = "/data"
+	dataDirectory string
 )
 
 // handleSignals handles OS signals so we can ensure we close database
@@ -137,8 +140,9 @@ func main() {
 
 	logger := loggerRaw.Sugar().Named("main")
 
-	if len(configuration.DataDirectory) != 0 {
-		dataDirectory = configuration.DataDirectory
+	dataDirectory = os.Getenv("DATA_DIR")
+	if len(dataDirectory) == 0 {
+		dataDirectory = defaultDataDirectory
 	}
 
 	cfg, err := dogecoin.LoadConfiguration(dataDirectory)


### PR DESCRIPTION
Generic config cleanup to get rid of the ".test" condition in configuration.go

- configuration.DataDirectory is only used in main.go, so we
  move it there.
- Don't read os.GetEnv() outside of functions.
- Don't build single-use vars, instead construct values based on consts
- Fix tests to not test uninitialized vars
